### PR TITLE
Allow wildcards in SSM parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "ssm_parameter_doc" {
       "ssm:GetParameters",
     ]
 
-    resources = formatlist("arn:aws:ssm:%s:%s:parameter/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, var.ssm_parameters[count.index])
+    resources = formatlist("arn:aws:ssm:%s:%s:parameter%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, var.ssm_parameters[count.index])
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,11 @@
 # PARAMETER STORE PARAMETERS.
 # ------------------------------------------------------------------------------
 
+# The AWS account ID being used
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
 # The user being created
 resource "aws_iam_user" "user" {
   name = var.user_name
@@ -12,13 +17,6 @@ resource "aws_iam_user" "user" {
 # The IAM access key for the user
 resource "aws_iam_access_key" "key" {
   user = aws_iam_user.user.name
-}
-
-# The SSM Parameter Store parameters of interest
-data "aws_ssm_parameter" "parameter" {
-  count = length(var.ssm_parameters)
-
-  name = var.ssm_parameters[count.index]
 }
 
 # IAM policy documents that allow reading the SSM Parameter Store
@@ -33,9 +31,7 @@ data "aws_iam_policy_document" "ssm_parameter_doc" {
       "ssm:GetParameters",
     ]
 
-    resources = [
-      data.aws_ssm_parameter.parameter[count.index].arn,
-    ]
+    resources = formatlist("arn:aws:ssm:%s:%s:parameter/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, var.ssm_parameters[count.index])
   }
 }
 


### PR DESCRIPTION
In the previous version of this code, SSM parameters with wildcards in them would generate a ValidationException before the terraform code could be applied, so this PR corrects that.