### PR TITLE
Add packer permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module "iam_user" {
 |------|-------------|:----:|:-------:|:--------:|
 | ssm_parameters | The AWS SSM parameters that the IAM user needs to be able to read | list(string) | | yes |
 | user_name | The name to associate with the AWS IAM user (e.g. test-ansible-role-cyhy-core) | string | | yes |
+| add_packer_permissions | Whether or not to give the IAM user the permissions needed by packer to create an AMI | bool | `false` | no |
 | tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
 
 ## Outputs ##

--- a/main.tf
+++ b/main.tf
@@ -43,3 +43,60 @@ resource "aws_iam_user_policy" "ssm_policy" {
   user   = aws_iam_user.user.id
   policy = data.aws_iam_policy_document.ssm_parameter_doc[count.index].json
 }
+
+# IAM policy documents that allow the EC2 actions needed for packer to create
+# AMIs.  This will be applied to the IAM user we are creating.
+data "aws_iam_policy_document" "ec2_packer_doc" {
+  count = var.add_packer_permissions ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:DeregisterImage",
+      "ec2:DeleteSnapshot",
+      "ec2:DescribeInstances",
+      "ec2:CreateKeyPair",
+      "ec2:DescribeRegions",
+      "ec2:CreateImage",
+      "ec2:CopyImage",
+      "ec2:ModifyImageAttribute",
+      "ec2:DescribeSnapshots",
+      "ec2:DeleteVolume",
+      "ec2:ModifySnapshotAttribute",
+      "ec2:CreateSecurityGroup",
+      "ec2:DescribeVolumes",
+      "ec2:CreateSnapshot",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DetachVolume",
+      "ec2:TerminateInstances",
+      "ec2:DescribeTags",
+      "ec2:CreateTags",
+      "ec2:RegisterImage",
+      "ec2:RunInstances",
+      "ec2:StopInstances",
+      "ec2:DescribeSecurityGroups",
+      "ec2:CreateVolume",
+      "ec2:DescribeImages",
+      "ec2:GetPasswordData",
+      "ec2:DescribeImageAttribute",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DescribeSubnets",
+      "ec2:DeleteKeyPair"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+# The EC2 policies for our IAM user that lets the user do the actions needed
+# by packer to build AMIs.
+resource "aws_iam_user_policy" "ec2_packer_policy" {
+  count = var.add_packer_permissions ? 1 : 0
+
+  user   = aws_iam_user.user.id
+  policy = data.aws_iam_policy_document.ec2_packer_doc.json
+}

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ resource "aws_iam_user_policy" "ssm_policy" {
 
   user   = aws_iam_user.user.id
   policy = data.aws_iam_policy_document.ssm_parameter_doc[count.index].json
+  name   = format("terraform_read_ssm_parameters_", count.index + 1)
 }
 
 # IAM policy documents that allow the EC2 actions needed for packer to create
@@ -99,4 +100,5 @@ resource "aws_iam_user_policy" "ec2_packer_policy" {
 
   user   = aws_iam_user.user.id
   policy = data.aws_iam_policy_document.ec2_packer_doc[count.index].json
+  name   = "terraform_ec2_access_for_packer_ami"
 }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_user_policy" "ssm_policy" {
 
   user   = aws_iam_user.user.id
   policy = data.aws_iam_policy_document.ssm_parameter_doc[count.index].json
-  name   = format("terraform_read_ssm_parameters_", count.index + 1)
+  name   = format("terraform_read_ssm_parameters_%d", count.index + 1)
 }
 
 # IAM policy documents that allow the EC2 actions needed for packer to create

--- a/main.tf
+++ b/main.tf
@@ -56,44 +56,44 @@ data "aws_iam_policy_document" "ec2_packer_doc" {
     actions = [
       "ec2:AttachVolume",
       "ec2:AuthorizeSecurityGroupIngress",
-      "ec2:DeregisterImage",
-      "ec2:DeleteSnapshot",
-      "ec2:DescribeInstances",
-      "ec2:CreateKeyPair",
-      "ec2:DescribeRegions",
-      "ec2:CreateImage",
       "ec2:CopyImage",
-      "ec2:ModifyImageAttribute",
-      "ec2:DescribeSnapshots",
-      "ec2:DeleteVolume",
-      "ec2:ModifySnapshotAttribute",
+      "ec2:CreateImage",
+      "ec2:CreateKeyPair",
       "ec2:CreateSecurityGroup",
-      "ec2:DescribeVolumes",
       "ec2:CreateSnapshot",
-      "ec2:ModifyInstanceAttribute",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DetachVolume",
-      "ec2:TerminateInstances",
-      "ec2:DescribeTags",
       "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteKeyPair",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteVolume",
+      "ec2:DeregisterImage",
+      "ec2:DescribeImageAttribute",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeRegions",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DetachVolume",
+      "ec2:GetPasswordData",
+      "ec2:ModifyImageAttribute",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifySnapshotAttribute",
       "ec2:RegisterImage",
       "ec2:RunInstances",
       "ec2:StopInstances",
-      "ec2:DescribeSecurityGroups",
-      "ec2:CreateVolume",
-      "ec2:DescribeImages",
-      "ec2:GetPasswordData",
-      "ec2:DescribeImageAttribute",
-      "ec2:DeleteSecurityGroup",
-      "ec2:DescribeSubnets",
-      "ec2:DeleteKeyPair"
+      "ec2:TerminateInstances",
     ]
 
     resources = ["*"]
   }
 }
 
-# The EC2 policies for our IAM user that lets the user do the actions needed
+# The EC2 policies for our IAM user that let the user do the actions needed
 # by packer to build AMIs.
 resource "aws_iam_user_policy" "ec2_packer_policy" {
   count = var.add_packer_permissions ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -98,5 +98,5 @@ resource "aws_iam_user_policy" "ec2_packer_policy" {
   count = var.add_packer_permissions ? 1 : 0
 
   user   = aws_iam_user.user.id
-  policy = data.aws_iam_policy_document.ec2_packer_doc.json
+  policy = data.aws_iam_policy_document.ec2_packer_doc[count.index].json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "user_name" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 
+variable "add_packer_permissions" {
+  type        = bool
+  description = "Whether or not to give the IAM user the permissions needed by packer to create an AMI"
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all AWS resources created"


### PR DESCRIPTION
This PR adds a new boolean flag to control whether or not we want to give our new IAM user the permissions needed by packer to create new AMIs.  While we're at it, we also give our inline user policies some human-readable names.