### PR TITLE
Modify the IAM policy so the user can access SSM resources in any region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,6 @@
 # The AWS account ID being used
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {}
-
 # The user being created
 resource "aws_iam_user" "user" {
   name = var.user_name
@@ -31,7 +29,7 @@ data "aws_iam_policy_document" "ssm_parameter_doc" {
       "ssm:GetParameters",
     ]
 
-    resources = formatlist("arn:aws:ssm:%s:%s:parameter%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, var.ssm_parameters[count.index])
+    resources = formatlist("arn:aws:ssm:*:%s:parameter%s", data.aws_caller_identity.current.account_id, var.ssm_parameters[count.index])
   }
 }
 


### PR DESCRIPTION
Currently, when the IAM user is created by this terraform module, it will only get access to SSM parameters in the region where the module was executed.  That may or may not be the same region used by the build process that requires this user in order to complete successfully.

With this change, it will not matter which region the build takes place in since the IAM user will have access to the specified SSM parameters in any region.