### PR TITLE
Create unified AMI creation role

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ module "iam_user" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | add_packer_permissions | Whether or not to give the IAM user the permissions needed by packer to create an AMI | bool | `false` | no |
-| ec2amicreate_role_name | The name of the IAM role in the Images account that allows all of the EC2 actions needed to create an AMI. | string | `EC2AMICreate` | no |
+| ec2amicreate_policy_name | The name of the IAM policy in the Images account that allows all of the actions needed to create an AMI. | string | `EC2AMICreate` | no |
+| ec2amicreate_role_description | The description to associate with the IAM role that allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user_name variable. | string | `Allows the %s IAM user to create AMIs` | no |
+| ec2amicreate_role_name | The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a "%s" in this value will get replaced with the user_name variable. | string | `EC2AMICreate-%s` | no |
 | images_account_id | The AWS account ID containing the SSM parameter store that the IAM user needs to read from and also where the user will be allowed to create images (if add_packer_permissions is true); if not provided, the current calling account ID is used | string | ID of calling account | no |
 | parameterstorereadonly_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the specified SSM Parameter Store parameters.  Note that a "%s" in this value will get replaced with the user_name variable. | string | `Allows read-only access to SSM Parameter Store parameters required for %s.` | no |
 | parameterstorereadonly_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the specified SSM Parameter Store parameters.  Note that a "%s" in this value will get replaced with the user_name variable. | string | `ParameterStoreReadOnly-%s` | no |

--- a/assume_ec2amicreate_role.tf
+++ b/assume_ec2amicreate_role.tf
@@ -9,17 +9,18 @@ data "aws_iam_policy_document" "assume_ec2amicreate_role_doc" {
     actions = ["sts:AssumeRole"]
 
     resources = [
-      "arn:aws:iam::${var.images_account_id}:role/${var.ec2amicreate_role_name}"
+      aws_iam_role.ec2amicreate_role[count.index].arn
     ]
   }
 }
 
+
 # The IAM policy allowing this user to assume their custom
 # EC2AMICreate role in the Images account
-resource "aws_iam_user_policy" "assume_ec2miwrite" {
+resource "aws_iam_user_policy" "assume_ec2amicreate" {
   count = var.add_packer_permissions ? 1 : 0
 
-  name   = "Images-Assume${var.ec2amicreate_role_name}"
+  name   = "Images-Assume${local.ec2amicreate_role_name}"
   user   = aws_iam_user.user.name
   policy = data.aws_iam_policy_document.assume_ec2amicreate_role_doc[count.index].json
 }

--- a/ec2amicreate_role.tf
+++ b/ec2amicreate_role.tf
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------------------
+# Create the IAM role that allows creation of AMIs and read-only access
+# to any specified SSM Parameter Store parameters in the Images account.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "ec2amicreate_role" {
+  count = var.add_packer_permissions ? 1 : 0
+
+  provider = aws.images-ProvisionEC2AMICreateRoles
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
+  description        = local.ec2amicreate_role_description
+  name               = local.ec2amicreate_role_name
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment" {
+  count = var.add_packer_permissions ? 1 : 0
+
+  provider = aws.images-ProvisionEC2AMICreateRoles
+
+  policy_arn = "arn:aws:iam::${local.images_account_id}:policy/${var.ec2amicreate_policy_name}"
+  role       = aws_iam_role.ec2amicreate_role[count.index].name
+}
+
+resource "aws_iam_role_policy_attachment" "ec2amicreate_parameterstorereadonly_policy_attachment" {
+  count = var.add_packer_permissions ? 1 : 0
+
+  provider = aws.images-ProvisionEC2AMICreateRoles
+
+  policy_arn = aws_iam_policy.parameterstorereadonly_policy.arn
+  role       = aws_iam_role.ec2amicreate_role[count.index].name
+}

--- a/examples/read_a_single_parameter/main.tf
+++ b/examples/read_a_single_parameter/main.tf
@@ -4,6 +4,13 @@ provider "aws" {
   profile = "cool-users-provisionaccount"
 }
 
+# ProvisionEC2AMICreateRoles AWS provider for the Images account
+provider "aws" {
+  region  = "us-east-1"
+  profile = "cool-images-provisionec2amicreateroles"
+  alias   = "images-ProvisionEC2AMICreateRoles"
+}
+
 # ProvisionParameterStoreReadRoles AWS provider for the Images account
 provider "aws" {
   region  = "us-east-1"
@@ -11,10 +18,10 @@ provider "aws" {
   alias   = "images-ProvisionParameterStoreReadRoles"
 }
 
-# Use aws_caller_identity with the Images account provider so we can pass the
-# Images account ID into the module below
+# Use aws_caller_identity with one of the Images account providers
+# so we can pass the Images account ID into the module below
 data "aws_caller_identity" "images" {
-  provider = aws.images-ProvisionParameterStoreReadRoles
+  provider = aws.images-ProvisionEC2AMICreateRoles
 }
 
 module "iam_user" {
@@ -22,6 +29,7 @@ module "iam_user" {
 
   providers = {
     aws                                         = aws
+    aws.images-ProvisionEC2AMICreateRoles       = aws.images-ProvisionEC2AMICreateRoles
     aws.images-ProvisionParameterStoreReadRoles = aws.images-ProvisionParameterStoreReadRoles
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -2,6 +2,16 @@
 data "aws_caller_identity" "current" {}
 
 locals {
+  # If var.ec2amicreate_role_description contains "%s", use format()
+  # to replace the "%s" with var.user_name, otherwise just use
+  # var.ec2amicreate_role_description as is
+  ec2amicreate_role_description = length(regexall(".*%s.*", var.ec2amicreate_role_description)) > 0 ? format(var.ec2amicreate_role_description, var.user_name) : var.parameterstorereadonly_role_description
+
+  # If var.ec2amicreate_role_name contains "%s", use format()
+  # to replace the "%s" with var.user_name, otherwise just use
+  # var.ec2amicreate_role_name as is
+  ec2amicreate_role_name = length(regexall(".*%s.*", var.ec2amicreate_role_name)) > 0 ? format(var.ec2amicreate_role_name, var.user_name) : var.ec2amicreate_role_name
+
   # If var.images_account_id is not set, default to the calling account
   images_account_id = var.images_account_id != "" ? var.images_account_id : data.aws_caller_identity.current.account_id
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,10 @@
-# This is the provider that is used to create the role and policy that can
+# This is the provider that is used to create the role that can
+# create AMIs inside the Images account
+provider "aws" {
+  alias = "images-ProvisionEC2AMICreateRoles"
+}
+
+# This is the provider that is used to create the policy that can
 # read Parameter Store parameters inside the Images account
 provider "aws" {
   alias = "images-ProvisionParameterStoreReadRoles"

--- a/variables.tf
+++ b/variables.tf
@@ -25,9 +25,19 @@ variable "add_packer_permissions" {
   default     = false
 }
 
-variable "ec2amicreate_role_name" {
-  description = "The name of the IAM role in the Images account that allows all of the EC2 actions needed to create an AMI."
+variable "ec2amicreate_policy_name" {
+  description = "The name of the IAM policy in the Images account that allows all of the actions needed to create an AMI."
   default     = "EC2AMICreate"
+}
+
+variable "ec2amicreate_role_description" {
+  description = "The description to associate with the IAM role that allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
+  default     = "Allows the %s IAM user to create AMIs."
+}
+
+variable "ec2amicreate_role_name" {
+  description = "The name to assign the IAM role that allows allows this IAM user to create AMIs.  Note that a \"%s\" in this value will get replaced with the user_name variable."
+  default     = "EC2AMICreate-%s"
 }
 
 variable "images_account_id" {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR creates a single, custom role that contains all permissions needed to create an AMI (including read access to specified parameter store parameters) and can be assumed by the user created by this module.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Previously, this module created a user with the ability to assume two different roles:
 * One standard role (`EC2AMICreate`) with permissions to create the AMI 
 * Another custom role (`ParameterStoreReadRole-*`) with permissions to read parameter store parameters

That proved to be a problem, since we create AMIs with `packer`, which expects all permissions to be included in the role that is assumed when `packer` is launched.  By consolidating all of the permissions into a single, custom role for this user, `packer` is able to successfully create AMIs.

Note that the `ParameterStoreReadRole-*` is still created (no changes to it in this PR), since it will be needed in use cases where AMI-creation permissions are not required.

See related PR https://github.com/cisagov/cool-accounts/pull/21.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
* The example test user was created and reviewed in the AWS console for accuracy.
* I created the `test-openvpn-packer` user (using updated code in https://github.com/cisagov/openvpn-packer; PR coming soon with those changes) and verified that I was able to successfully create an AMI with that user.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
