### PR TITLE
Add "sts:TagSession" Permissions

### DIFF
--- a/assume_ec2amicreate_role.tf
+++ b/assume_ec2amicreate_role.tf
@@ -6,7 +6,10 @@ data "aws_iam_policy_document" "assume_ec2amicreate_role_doc" {
   statement {
     effect = "Allow"
 
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
 
     resources = [
       aws_iam_role.ec2amicreate_role[count.index].arn

--- a/assume_role_policy_doc.tf
+++ b/assume_role_policy_doc.tf
@@ -8,6 +8,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
   statement {
     actions = [
       "sts:AssumeRole",
+      "sts:TagSession",
     ]
 
     principals {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR adds `sts:TagSession` permissions to the role and policy that allows assumption of `EC2AMICreate-*` roles.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
I discovered that `sts:TagSession` is needed in order for the GitHub action [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) (recently added to the new https://github.com/cisagov/skeleton-packer-cool repo and soon to be used by all of our `packer` repos) to function properly.  This permission will also be needed by any other processes that tag a session when assuming an `EC2AMICreate-*` role.
 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I applied these permissions and I stopped getting errors like `AccessDenied: User: xyz is not authorized to perform: sts:TagSession on resource: xyz` and instead started getting AMIs that were successfully built by GitHub Actions, [as seen here](https://github.com/cisagov/skeleton-packer-cool/runs/463868364).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
