### PR TITLE
Tag Build Role for GitHub Secret

### DIFF
--- a/ec2amicreate_role.tf
+++ b/ec2amicreate_role.tf
@@ -11,7 +11,12 @@ resource "aws_iam_role" "ec2amicreate_role" {
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
   description        = local.ec2amicreate_role_description
   name               = local.ec2amicreate_role_name
-  tags               = var.tags
+  tags = merge(var.tags,
+    {
+      "GitHub_Secret_Name"             = "BUILD_ROLE_TO_ASSUME",
+      "GitHub_Secret_Terraform_Lookup" = "arn"
+    }
+  )
 }
 
 resource "aws_iam_role_policy_attachment" "ec2amicreate_policy_attachment" {


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds two tags to the custom `EC2AMICreate` role.  These tags will enable downstream assignment of the role's ARN to a GitHub Secret.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We want to simplify the process for creating AMIs as much as possible.  One way we are doing that is with a [script that automatically sets some required GitHub Secrets](https://github.com/cisagov/development-guide/tree/develop/project_setup#terraform-iam-credentials-to-github-secrets-).  The tags being added in this PR will allow that script to create the `BUILD_ROLE_TO_ASSUME` secret and assign it the value of the `EC2AMICreate` role's ARN.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I did a `terraform apply` for the [skeleton-packer-cool test user](https://github.com/cisagov/skeleton-packer-cool/tree/develop/terraform-test-user) and verified that the tags were applied as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
